### PR TITLE
feat: add new method to protocol to send model

### DIFF
--- a/ZappAnalyticsPluginsSDK.podspec
+++ b/ZappAnalyticsPluginsSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name  = "ZappAnalyticsPluginsSDK"
-  s.version = '6.0.1'
+  s.version = '6.0.2'
   s.platform  = :ios, '9.0'
   s.summary = "ZappAnalyticsPluginsSDK"
   s.description = "ZappAnalyticsPluginsSDK container."

--- a/ZappAnalyticsPluginsSDK/AnalyticsManager/Protocols/ZPAnalyticsProviderProtocol.swift
+++ b/ZappAnalyticsPluginsSDK/AnalyticsManager/Protocols/ZPAnalyticsProviderProtocol.swift
@@ -59,6 +59,7 @@ import ZappPlugins
      */
     @objc optional func trackEvent(_ eventName:String)
     @objc optional func trackEvent(_ eventName:String, parameters:[String:NSObject])
+    @objc optional func trackEvent(_ eventName:String, parameters:[String:NSObject], model: Any?)
     @objc optional func trackEvent(_ eventName:String, message:String, exception:NSException)
     @objc optional func trackEvent(_ eventName:String, message:String, error:NSError)
     @objc optional func trackEvent(_ eventName:String, timed:Bool)

--- a/ZappAnalyticsPluginsSDK/Info.plist
+++ b/ZappAnalyticsPluginsSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
- Add optional method to protocol which will include sending also the model to the analytics provider
- It's needed for a new pro7 GA plugin which needs to look at the model to determine some params which will be sent to for the event tracking